### PR TITLE
Prevent Join/Quit message for admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ buildNumber.properties
 .mvn/timing.properties
 # https://github.com/takari/maven-wrapper#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar
+.settings/
+.classpath
+.project
 
 ### JetBrains template
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider

--- a/bungee/src/main/java/fr/freebuild/playerjoingroup/bungee/MessagesManager.java
+++ b/bungee/src/main/java/fr/freebuild/playerjoingroup/bungee/MessagesManager.java
@@ -168,8 +168,8 @@ public class MessagesManager {
         });
     }
 
-    public void sendQueryHasPlayedBefore(String serverName, String playerUUID) { // TODO refactor / extract methods / make  Query a core component
-        ProxiedPlayer player =  this.plugin.getProxy().getPlayer(UUID.fromString(playerUUID));
+    public void sendQueryHasPlayedBefore(String serverName, ProxiedPlayer player) { // TODO refactor / extract methods / make  Query a core component
+        UUID playerUUID =  player.getUniqueId();
         Config config = this.plugin.getConfig();
         String group = Utils.getServerGroupName(serverName, config);
 
@@ -177,7 +177,7 @@ public class MessagesManager {
         int queryHashCode = query.hashCode();
 
         Packet packet = new Packet.Builder(Subchannel.QUERY)
-                .setData(playerUUID)
+                .setData(playerUUID.toString())
                 .setQuery(QueryType.HAS_PLAYED_BEFORE)
                 .setServerGroup(group) // TODO refactor (simplify packet)
                 .setHashCode(queryHashCode)
@@ -196,12 +196,14 @@ public class MessagesManager {
                     Packet hasPlayedBeforePacket = new Packet.Builder(Subchannel.EVENT)
                             .setData(player.getName())
                             .setEventType(EventType.HAS_PLAYED_BEFORE)
+                            .setPlayerUuid(playerUUID)
                             .setServerGroup(group)
                             .build();
                     sendToAll(hasPlayedBeforePacket);
                 } else {
                     Packet greetingPacket = new Packet.Builder(Subchannel.EVENT)
                             .setData(player.getName())
+                            .setPlayerUuid(playerUUID)
                             .setEventType(EventType.FIRST_GROUP_CONNECTION)
                             .setServerGroup(group) // TODO refactor (simplify packet)
                             .build();

--- a/bungee/src/main/java/fr/freebuild/playerjoingroup/bungee/listener/ConnectionListener.java
+++ b/bungee/src/main/java/fr/freebuild/playerjoingroup/bungee/listener/ConnectionListener.java
@@ -41,6 +41,7 @@ public abstract class ConnectionListener implements Listener {
         Packet packet = new Packet.Builder(Subchannel.EVENT)
                 .setData(player.getUniqueId().toString())
                 .appendParam("PLAYER_NAME", player.getName())
+                .setPlayerUuid(player.getUniqueId())
                 .setEventType(event)
                 .setServerGroup(group)
                 .build();

--- a/bungee/src/main/java/fr/freebuild/playerjoingroup/bungee/listener/PlayerJoinListener.java
+++ b/bungee/src/main/java/fr/freebuild/playerjoingroup/bungee/listener/PlayerJoinListener.java
@@ -23,7 +23,7 @@ public class PlayerJoinListener extends ConnectionListener {
             ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
 
             service.schedule(() -> {
-                this.plugin.getMessagesManager().sendQueryHasPlayedBefore(event.getTarget().getName(), player.getUniqueId().toString());
+                this.plugin.getMessagesManager().sendQueryHasPlayedBefore(event.getTarget().getName(), player);
             }, 1, TimeUnit.SECONDS);
         }
     }

--- a/bungee/src/main/java/fr/freebuild/playerjoingroup/bungee/listener/PlayerSwitchListener.java
+++ b/bungee/src/main/java/fr/freebuild/playerjoingroup/bungee/listener/PlayerSwitchListener.java
@@ -34,7 +34,7 @@ public class PlayerSwitchListener extends ConnectionListener {
 
                 ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
                 service.schedule(() -> {
-                    this.plugin.getMessagesManager().sendQueryHasPlayedBefore(player.getServer().getInfo().getName(), player.getUniqueId().toString());
+                    this.plugin.getMessagesManager().sendQueryHasPlayedBefore(player.getServer().getInfo().getName(), player);
                 }, 1, TimeUnit.SECONDS);
             }
         }

--- a/core/src/main/java/fr/freebuild/playerjoingroup/core/protocol/Packet.java
+++ b/core/src/main/java/fr/freebuild/playerjoingroup/core/protocol/Packet.java
@@ -4,6 +4,7 @@ import fr.freebuild.playerjoingroup.core.event.EventType;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 public class Packet {
     private String subchannel;
@@ -48,6 +49,10 @@ public class Packet {
 
         public Builder setQuery(QueryType query) {
             return this.appendParam(ParamsKey.QUERY.getValue(), query.getValue());
+        }
+
+        public Builder setPlayerUuid(UUID uuid) {
+            return this.appendParam(ParamsKey.PLAYER_UUID.getValue(), uuid.toString());
         }
 
         public Builder setHashCode(Integer hashCode) {

--- a/core/src/main/java/fr/freebuild/playerjoingroup/core/protocol/ParamsKey.java
+++ b/core/src/main/java/fr/freebuild/playerjoingroup/core/protocol/ParamsKey.java
@@ -4,7 +4,8 @@ public enum ParamsKey {
     SERVER_GROUP("serverGroup"),
     EVENT("event"),
     QUERY("query"),
-    HASH_CODE("hashCode");
+    HASH_CODE("hashCode"),
+    PLAYER_UUID("playerUUID");
 
     private String value;
 

--- a/spigot/src/main/java/fr/freebuild/playerjoingroup/spigot/MessagesManager.java
+++ b/spigot/src/main/java/fr/freebuild/playerjoingroup/spigot/MessagesManager.java
@@ -174,9 +174,7 @@ public class MessagesManager {
     }
 
     private void onPlayerLeave(Packet packet) {
-        String playerName = packet.getParams().get("PLAYER_NAME");
-        String message = Utils.getConfigString("QuitMessage");
-        message = Utils.format(message, FormatParam.PLAYER, playerName);
+        String message = Utils.getPlayerLeaveMessage(packet.getData());
         getServer().broadcastMessage(message);
     }
 
@@ -204,16 +202,12 @@ public class MessagesManager {
     }
 
     private void onFirstConnection(String playerName) {
-        String message = Utils.getConfigString("FirstJoinMessage");
-        final Integer counter = Utils.increaseCounter("PlayerCounter");
-        message = Utils.format(message, FormatParam.COUNTER, counter.toString());
-        message = Utils.format(message, FormatParam.PLAYER, playerName);
+        String message = Utils.getFirstConnectionMessage(playerName);
         getServer().broadcastMessage(message);
     }
 
     private void onHasPlayedBefore(Packet packet) {
-        String message = Utils.getConfigString("JoinMessage");
-        message = Utils.format(message, FormatParam.PLAYER, packet.getData());
+        String message = Utils.getHasPlayedBeforeMessage(packet.getData());
         getServer().broadcastMessage(message);
     }
 

--- a/spigot/src/main/java/fr/freebuild/playerjoingroup/spigot/MessagesManager.java
+++ b/spigot/src/main/java/fr/freebuild/playerjoingroup/spigot/MessagesManager.java
@@ -8,6 +8,7 @@ import fr.freebuild.playerjoingroup.spigot.utils.Utils;
 
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -19,7 +20,6 @@ import java.util.Queue;
 import java.util.UUID;
 
 import static org.bukkit.Bukkit.*;
-import static org.bukkit.Bukkit.getServer;
 
 // TODO split in different file?
 
@@ -151,7 +151,7 @@ public class MessagesManager {
         switch (eventType) {
             case JOIN_SERVER_GROUP -> onPlayerJoin(packet);
             case LEAVE_SERVER_GROUP -> onPlayerLeave(packet);
-            case FIRST_GROUP_CONNECTION -> onFirstConnection(packet.getData());
+            case FIRST_GROUP_CONNECTION -> onFirstConnection(packet);
             case HAS_PLAYED_BEFORE -> onHasPlayedBefore(packet);
             default -> getLogger().warning("Unknown event: " + event);
         }
@@ -174,8 +174,10 @@ public class MessagesManager {
     }
 
     private void onPlayerLeave(Packet packet) {
-        String message = Utils.getPlayerLeaveMessage(packet.getData());
-        getServer().broadcastMessage(message);
+        if (canDisplayMessage(packet, "essentials.silentquit"))  {
+            String message = Utils.getPlayerLeaveMessage(packet.getParams().get("PLAYER_NAME"));
+            getServer().broadcastMessage(message);
+        }
     }
 
     private void onPlayerJoin(Packet packet) throws InvalidPacketException, ConstructPacketErrorException, IOException {
@@ -201,14 +203,25 @@ public class MessagesManager {
         this.send(Protocol.constructPacket(packet));
     }
 
-    private void onFirstConnection(String playerName) {
-        String message = Utils.getFirstConnectionMessage(playerName);
-        getServer().broadcastMessage(message);
+    private void onFirstConnection(Packet packet) {
+        if (canDisplayMessage(packet, "essentials.silentjoin"))  {
+            String message = Utils.getFirstConnectionMessage(packet.getData());
+            getServer().broadcastMessage(message);
+        }
     }
 
     private void onHasPlayedBefore(Packet packet) {
-        String message = Utils.getHasPlayedBeforeMessage(packet.getData());
-        getServer().broadcastMessage(message);
+        if (canDisplayMessage(packet, "essentials.silentjoin"))  {
+            String message = Utils.getHasPlayedBeforeMessage(packet.getData());
+            getServer().broadcastMessage(message);
+        }
+    }
+
+    private Boolean canDisplayMessage(Packet packet, String perm) {
+        UUID playerUUID = UUID.fromString(packet.getParams().get(ParamsKey.PLAYER_UUID.getValue()));
+        Player player = getOfflinePlayer(playerUUID).getPlayer();
+
+        return player == null || !player.hasPermission(perm);
     }
 
     private class ConnectionToServer {

--- a/spigot/src/main/java/fr/freebuild/playerjoingroup/spigot/listener/PlayerJoinListener.java
+++ b/spigot/src/main/java/fr/freebuild/playerjoingroup/spigot/listener/PlayerJoinListener.java
@@ -33,18 +33,8 @@ public class PlayerJoinListener implements Listener {
         if (!player.hasPlayedBefore() && PlayerJoinGroup.plugin.getFireworkBuilder().getActivateOnJoin())
             PlayerJoinGroup.plugin.getFireworkBuilder().spawn(player);
 
-        if (this.plugin.isEnabled()) {
-            event.setJoinMessage(null);
-            if (!this.plugin.isMessageManagerEnabled()) {
-                String playerName = event.getPlayer().getDisplayName();
-                if (!event.getPlayer().hasPlayedBefore()) {
-                    this.onFirstConnection(playerName);
-                } else {
-                    this.onHasPlayedBefore(playerName);
-                }
-            }
-        }
-        else {
+        event.setJoinMessage(null);
+        if (!this.plugin.isMessageManagerEnabled()) {
             String playerName = event.getPlayer().getDisplayName();
             if (!event.getPlayer().hasPlayedBefore()) {
                 this.onFirstConnection(playerName);
@@ -62,13 +52,8 @@ public class PlayerJoinListener implements Listener {
      */
     @EventHandler
     public void onPlayerQuit(PlayerQuitEvent event) {
-        if (this.plugin.isEnabled()) {
-            event.setQuitMessage(null);
-            if (!this.plugin.isMessageManagerEnabled()) {
-                this.onPlayerLeave(event.getPlayer().getDisplayName());
-            }
-        }
-        else {
+        event.setQuitMessage(null);
+        if (!this.plugin.isMessageManagerEnabled()) {
             this.onPlayerLeave(event.getPlayer().getDisplayName());
         }
     }

--- a/spigot/src/main/java/fr/freebuild/playerjoingroup/spigot/listener/PlayerJoinListener.java
+++ b/spigot/src/main/java/fr/freebuild/playerjoingroup/spigot/listener/PlayerJoinListener.java
@@ -1,7 +1,5 @@
 package fr.freebuild.playerjoingroup.spigot.listener;
 
-import static org.bukkit.Bukkit.getServer;
-
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -32,14 +30,15 @@ public class PlayerJoinListener implements Listener {
         if (!player.hasPlayedBefore() && PlayerJoinGroup.plugin.getFireworkBuilder().getActivateOnJoin())
             PlayerJoinGroup.plugin.getFireworkBuilder().spawn(player);
 
-        event.setJoinMessage(null);
         if (!this.plugin.isMessageManagerEnabled()) {
             String message;
             if (!player.hasPlayedBefore())
                 message = Utils.getFirstConnectionMessage(player.getDisplayName());
             else
                 message = Utils.getHasPlayedBeforeMessage(player.getDisplayName());
-            getServer().broadcastMessage(message);
+            event.setJoinMessage(message);
+        } else {
+            event.setJoinMessage(null);
         }
     }
 
@@ -51,9 +50,10 @@ public class PlayerJoinListener implements Listener {
      */
     @EventHandler
     public void onPlayerQuit(PlayerQuitEvent event) {
-        event.setQuitMessage(null);
         if (!this.plugin.isMessageManagerEnabled())
-            getServer().broadcastMessage(Utils.getPlayerLeaveMessage(event.getPlayer().getDisplayName()));
+            event.setQuitMessage(Utils.getPlayerLeaveMessage(event.getPlayer().getDisplayName()));
+        else
+            event.setQuitMessage(null);
     }
 
 }

--- a/spigot/src/main/java/fr/freebuild/playerjoingroup/spigot/listener/PlayerJoinListener.java
+++ b/spigot/src/main/java/fr/freebuild/playerjoingroup/spigot/listener/PlayerJoinListener.java
@@ -1,16 +1,15 @@
 package fr.freebuild.playerjoingroup.spigot.listener;
 
-import fr.freebuild.playerjoingroup.spigot.PlayerJoinGroup;
+import static org.bukkit.Bukkit.getServer;
 
-import fr.freebuild.playerjoingroup.spigot.utils.FormatParam;
-import fr.freebuild.playerjoingroup.spigot.utils.Utils;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
-import static org.bukkit.Bukkit.getServer;
+import fr.freebuild.playerjoingroup.spigot.PlayerJoinGroup;
+import fr.freebuild.playerjoingroup.spigot.utils.Utils;
 
 public class PlayerJoinListener implements Listener {
 
@@ -35,12 +34,12 @@ public class PlayerJoinListener implements Listener {
 
         event.setJoinMessage(null);
         if (!this.plugin.isMessageManagerEnabled()) {
-            String playerName = event.getPlayer().getDisplayName();
-            if (!event.getPlayer().hasPlayedBefore()) {
-                this.onFirstConnection(playerName);
-            } else {
-                this.onHasPlayedBefore(playerName);
-            }
+            String message;
+            if (!player.hasPlayedBefore())
+                message = Utils.getFirstConnectionMessage(player.getDisplayName());
+            else
+                message = Utils.getHasPlayedBeforeMessage(player.getDisplayName());
+            getServer().broadcastMessage(message);
         }
     }
 
@@ -53,28 +52,8 @@ public class PlayerJoinListener implements Listener {
     @EventHandler
     public void onPlayerQuit(PlayerQuitEvent event) {
         event.setQuitMessage(null);
-        if (!this.plugin.isMessageManagerEnabled()) {
-            this.onPlayerLeave(event.getPlayer().getDisplayName());
-        }
+        if (!this.plugin.isMessageManagerEnabled())
+            getServer().broadcastMessage(Utils.getPlayerLeaveMessage(event.getPlayer().getDisplayName()));
     }
 
-    private void onFirstConnection(String playerName) {
-        String message = Utils.getConfigString("FirstJoinMessage");
-        final Integer counter = Utils.increaseCounter("PlayerCounter");
-        message = Utils.format(message, FormatParam.COUNTER, counter.toString());
-        message = Utils.format(message, FormatParam.PLAYER, playerName);
-        getServer().broadcastMessage(message);
-    }
-
-    private void onHasPlayedBefore(String playerName) {
-        String message = Utils.getConfigString("JoinMessage");
-        message = Utils.format(message, FormatParam.PLAYER, playerName);
-        getServer().broadcastMessage(message);
-    }
-
-    private void onPlayerLeave(String playerName) {
-        String message = Utils.getConfigString("QuitMessage");
-        message = Utils.format(message, FormatParam.PLAYER, playerName);
-        getServer().broadcastMessage(message);
-    }
 }

--- a/spigot/src/main/java/fr/freebuild/playerjoingroup/spigot/utils/Utils.java
+++ b/spigot/src/main/java/fr/freebuild/playerjoingroup/spigot/utils/Utils.java
@@ -50,4 +50,22 @@ public class Utils {
         PlayerJoinGroup.plugin.saveConfig();
         return counter;
     }
+
+    public static String getFirstConnectionMessage(String playerName) {
+        final Integer counter = increaseCounter("PlayerCounter");
+        String message = getConfigString("FirstJoinMessage");
+        message = Utils.format(message, FormatParam.COUNTER, counter.toString());
+        message = Utils.format(message, FormatParam.PLAYER, playerName);
+        return message;
+    }
+
+    public static String getHasPlayedBeforeMessage(String playerName) {
+        String message = getConfigString("JoinMessage");
+        return Utils.format(message, FormatParam.PLAYER, playerName);
+    }
+
+    public static String getPlayerLeaveMessage(String playerName) {
+        String message = getConfigString("QuitMessage");
+        return Utils.format(message, FormatParam.PLAYER, playerName);
+    }
 }


### PR DESCRIPTION
On join, if the player has permission `essentials.silentjoin` it doesn't display join message.
On quit, if the player has permission `essentials.silentquit` it doesn't display quit message.